### PR TITLE
feat: add custom fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,10 +14,11 @@ html, body, #__next {
 body {
   color: var(--fg);
   background: var(--bg);
+  @apply font-text;
 }
 
 .display {
-  @apply uppercase tracking-[.32em];
+  @apply uppercase tracking-[.32em] font-display;
 }
 
 .prose-narrow {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { display, text } from "@/lib/fonts";
 
 export const metadata: Metadata = {
   title: "THE PORTFOLIO · 2025 — Lucía Fontalba",
@@ -8,8 +9,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="antialiased">{children}</body>
+    <html lang="en" className={`${display.variable} ${text.variable}`}>
+      <body className="antialiased font-text">{children}</body>
     </html>
   );
 }

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,11 @@
+import { Playfair_Display, Inter } from 'next/font/google';
+
+export const display = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-display',
+});
+
+export const text = Inter({
+  subsets: ['latin'],
+  variable: '--font-text',
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        display: ['var(--font-display)', 'serif'],
+        text: ['var(--font-text)', 'sans-serif'],
+      },
       letterSpacing: {
         wider: ".2em",
         widest: ".32em"


### PR DESCRIPTION
## Summary
- integrate Playfair Display and Inter via next/font
- configure Tailwind to expose display/text font families
- apply fonts to global styles and layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7ea88708832b8f63605471a53821